### PR TITLE
Use full license text and update various references

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,6 +1,6 @@
 # State Vector Sync API Description
 
-This page describes the API of [State Vector Sync (SVS)](README.md). While there are implementations of SVS for multiple programming languages available, the basic API is the same across all official implementations.
+This page describes the API of [State Vector Sync (SVS)](/README.md). While there are implementations of SVS for multiple programming languages available, the basic API is the same across all official implementations.
 
 The three components of an SVS library are:
 
@@ -10,7 +10,7 @@ The three components of an SVS library are:
 
 ## SVSPubSub API
 
-The `SVSPubSub` class provides a high level Pub/Sub interface built over SVS, originally described [here](https://dl.acm.org/doi/abs/10.1145/3460417.3483376).
+The `SVSPubSub` class provides a high level Pub/Sub interface built over SVS, originally described [here](https://doi.org/10.1145/3460417.3483376).
 
 * `SVSPubSub(Name syncPrefix, Name nodePrefix, Face, UpdateCallback, SecurityOptions)` - registers prefixes and starts Sync.
 * `SVSPubSub::publish(Name, Buffer)` - publishes a buffer of data with a given name to the Sync group.
@@ -49,8 +49,8 @@ Derived classes must define:
 
 ## License
 
-State Vector Sync is an open source project licensed under the CC-BY-SA 4.0. See [LICENSE](LICENSE) for more information.
-
 ![CC-BY-SA](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/by-sa.svg)
+
+State Vector Sync is an open source project licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/). See [LICENSE](/LICENSE) for more information.
 
 Different licenses for the implementations might apply.

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,59 @@
+Attribution-ShareAlike 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
 Creative Commons Attribution-ShareAlike 4.0 International Public
 License
 
@@ -247,8 +303,8 @@ apply to Your use of the Licensed Material:
      contents in a database in which You have Sui Generis Database
      Rights, then the database in which You have Sui Generis Database
      Rights (but not its individual contents) is Adapted Material,
-
      including for purposes of Section 3(b); and
+
   c. You must comply with the conditions in Section 3(a) if You Share
      all or a substantial portion of the contents of the database.
 

--- a/PubSubSpec.md
+++ b/PubSubSpec.md
@@ -1,8 +1,8 @@
 # State Vector Sync Pub/Sub Specification
 
-This page describes the specification of the SVS-PS protocol. SVS-PS runs on top of State Vector Sync and performs the additional functions described here.
+This page describes the specification of the SVS-PS protocol. SVS-PS runs on top of [State Vector Sync](Specification.md) and performs the additional functions described here.
 
-**Last update to specification**: 2022-12-27
+_Last update to specification: 2022-12-27_
 
 ## Overview
 
@@ -125,3 +125,11 @@ Implmentations of SVS-PS SHOULD provide security primitives to applications. If 
 1. Each data packet MUST be validated before being returned to the application. The outer data packet MUST be validated before decapsulation. Only validated segments must be reassembled and returned to the application.
 1. If data validation fails, the application SHOULD be notified of the failure. Implementations SHOULD provide an option to retry fetching segments that could not be validated.
 1. If desegmentation is done asynchronously, the application MUST be notified of the failure to validate a segment if some data has already been returned to the application.
+
+## License
+
+![CC-BY-SA](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/by-sa.svg)
+
+State Vector Sync is an open source project licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/). See [LICENSE](/LICENSE) for more information.
+
+Different licenses for the implementations might apply.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Specification and API description of the State Vector Sync (SVS) protocol.
 
-[State Vector Sync (SVS)](https://named-data.net/wp-content/uploads/2021/05/ndn-0073-r1-SVS.pdf) is an NDN transport layer protocol that allows efficient multi-producer/multi-consumer communication. The communication participants maintain a shared data set and whenever a participant publishes data to the data set, the other participants are informed about the data generation and can choose to retrieve the published data.
+[State Vector Sync (SVS)](https://named-data.net/wp-content/uploads/2021/07/ndn-0073-r2-SVS.pdf) is an NDN transport layer protocol that allows efficient multi-producer/multi-consumer communication. The communication participants maintain a shared data set and whenever a participant publishes data to the data set, the other participants are informed about the data generation and can choose to retrieve the published data.
 
 In SVS, the data set state is synchronized using a state vector. Every participant publishes Data under its own producer prefix, and to distinguish subsequent publications, the publications are enumerated using a sequence number. The highest sequence numbers of every participant are exchanged among all communicating participants in a state vector. Whenever receiving a state vector, new publications from other participants can be inferred and retrieved using Interest-Data exchange. The process of data set synchronization is elaborated in more detail in the Protocol Specification below.
 
@@ -14,9 +14,9 @@ Currently, there are three implementations of SVS available:
 
 ## Using State Vector Sync
 
-Examples for using SVS can be found in the `./examples` folder of the individual implementations. If you enjoyed using State Vector Sync, or used it for your research, we'd appreciate a citations on the following publication:
+Examples for using SVS can be found in the `examples` folder of the individual implementations. If you enjoyed using State Vector Sync, or used it for your research, we'd appreciate a citation on the following publication:
 
-Philipp Moll, Varun Patil, Nishant Sabharwal, Lixia Zhang, “A Brief Introduction to State Vector Sync”, NDN Technical Report, NDN-0073, Revision 2, July, 2021 [https://named-data.net/wp-content/uploads/2021/07/ndn-0073-r2-SVS.pdf](https://named-data.net/wp-content/uploads/2021/07/ndn-0073-r2-SVS.pdf)
+Philipp Moll, Varun Patil, Nishant Sabharwal, Lixia Zhang, *"A Brief Introduction to State Vector Sync"*, NDN Technical Report NDN-0073, Revision 2, July 2021. <https://named-data.net/wp-content/uploads/2021/07/ndn-0073-r2-SVS.pdf>
 
 ## Protocol Specification
 
@@ -28,13 +28,12 @@ The API is unified across the official libraries. Please find a detailed API des
 
 ## Example Applications
 
-- [ChronoChat](https://github.com/named-data/chronochat): A C++ chat client featuring the C++ version of SVS for group communication
 - [SVChat](https://github.com/pulsejet/svchat): An Angular-based chat application featuring the TypeScript version of SVS for group communication.
 
 ## License
 
-State Vector Sync is an open source project licensed under the CC-BY-SA 4.0. See [LICENSE](LICENSE) for more information.
-
 ![CC-BY-SA](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/by-sa.svg)
+
+State Vector Sync is an open source project licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/). See [LICENSE](/LICENSE) for more information.
 
 Different licenses for the implementations might apply.

--- a/Specification.md
+++ b/Specification.md
@@ -1,8 +1,8 @@
 # State Vector Sync Protocol Specification
 
-This page describes the protocol specification of [State Vector Sync](README.md).
+This page describes the protocol specification of [State Vector Sync (SVS)](/README.md).
 
-**Last update to specification**: 2021-12-15
+_Last update to specification: 2021-12-15_
 
 ## 1. Basic Protocol Design
 
@@ -36,7 +36,6 @@ seq=11                                  \
    | ---------------------> |           |
    |                        |           /
    |                        |          /
-
 ```
 
 ## 2. Format and Naming
@@ -71,7 +70,7 @@ SEQ-NO-TYPE = 204
 
 - The encoded state vector in the Interest consists of State Vector Entries
 - Each entry is a tuple of the NodeID of each node followed by its latest sequence number
-- Node names in the encoded version vector are ordered in [NDN canonical order](https://named-data.net/doc/NDN-packet-spec/0.3/name.html#canonical-order) to allow for Interest aggregation.
+- Node names in the encoded version vector are ordered in [NDN canonical order](https://docs.named-data.net/NDN-packet-spec/0.3/name.html#canonical-order) to allow for Interest aggregation.
 - Definition: _A State Vector A is outdated to State Vector B, if A contains any entry with seq number strictly smaller than in B._
 
 ## 4. State Sync
@@ -115,9 +114,9 @@ When a node is in _Supression State_:
 
 - Only aggregate state vector of incoming Sync Interests. No further action in _Suppression State_.
 
-## 5 Examples
+## 5. Examples
 
-### 5.1 State Sync - Example without loss
+### 5.1 State Sync - Example without packet loss
 
 Sync Group with 3 participants, node A, B, and C.
 
@@ -127,7 +126,7 @@ Sync Group with 3 participants, node A, B, and C.
 - B and C receive Sync Interest and update their local states accordingly.
 - _Consistent state is re-established_
 
-### 5.2 State Sync - Example **with** packet loss
+### 5.2 State Sync - Example with packet loss
 
 Sync Group with 3 participants, node A, B, and C.
 
@@ -144,21 +143,21 @@ Sync Group with 3 participants, node A, B, and C.
 - C also receives A’s Sync Interest and updates the state accordingly.
 - _Consistent state is re-established_
 
-## 6 SVS State Machine
+## 6. SVS State Machine
 
-![SVS State Machine](./img/svs-state-machine.jpg)
+![SVS State Machine](img/svs-state-machine.jpg)
 
-## 7 Interest Authentication
+## 7. Interest Authentication
 
-- Sync Interests are signed using the [Signed Interest v0.3](https://named-data.net/doc/NDN-packet-spec/0.3/signed-interest.html) format
+- Sync Interests are signed using the [Signed Interest v0.3](https://docs.named-data.net/NDN-packet-spec/0.3/signed-interest.html) format
 - All nodes must maintain the list of trusted publishers when using asymmetric signatures
   - This mechanism is beyond the scope of the Sync protocol
 - _Note:_ Interest aggregation cannot function when using asymmetric signatures
 
 ## License
 
-State Vector Sync is an open source project licensed under the CC-BY-SA 4.0. See [LICENSE](LICENSE) for more information.
-
 ![CC-BY-SA](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/by-sa.svg)
+
+State Vector Sync is an open source project licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/). See [LICENSE](/LICENSE) for more information.
 
 Different licenses for the implementations might apply.


### PR DESCRIPTION
The `LICENSE` file is missing a couple of paragraphs at the beginning compared to the [canonical plaintext version of the CC-BY-SA](https://creativecommons.org/licenses/by-sa/4.0/legalcode.txt). This confuses some automated tools and prevents them from correctly detecting the license of this repo. The first commit fixes that by including the _full_ text of the license.

The second commit is mostly just updating a few references throughout. Also drops ChronoChat as example app since it's not actually using SVS.