### PR TITLE
Change jekyll theme to `minima`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,12 +1,14 @@
-plugins:
-  - jekyll-relative-links
-relative_links:
-  enabled: true
-  collections: true
-include:
-  - API.md
-  - README.md
-  - Specification.md
-  - LICENSE
-
-theme: jekyll-theme-slate
+remote_theme: jekyll/minima@32468f51758b0b37c2b1f423265d4f29db461b27
+minima:
+  skin: auto
+  social_links:
+    - platform: github
+      user_url: https://github.com/named-data/StateVectorSync
+    - platform: twitter
+      user_url: https://twitter.com/NamedData
+header_pages:
+  # remove navigation links from the top of the page
+  -
+titles_from_headings:
+  # prevent duplicate page titles
+  strip_title: true


### PR DESCRIPTION
I know this is a matter of personal taste and thus highly subjective, however there are a couple of somewhat objective reasons for the change, namely:

* _minima_ is the only theme among those listed [here](https://pages.github.com/themes/) that has seen any commit activity in the past 1.5 years
* it supports light/dark "skins" with automatic switching based on the `prefers-color-scheme` CSS feature
* the current theme (_slate_) has some (admittedly very minor) visual issues on mobile browsers

That being said, if others don't like it, I'll withdraw this PR.