### PR TITLE
RFC: add additional block section to mapping data

### DIFF
--- a/PubSubSpec.md
+++ b/PubSubSpec.md
@@ -2,7 +2,7 @@
 
 This page describes the specification of the SVS-PS protocol. SVS-PS runs on top of [State Vector Sync](Specification.md) and performs the additional functions described here.
 
-_Last update to specification: 2022-12-27_
+_Last update to specification: 2023-05-19_
 
 ## Overview
 
@@ -82,6 +82,14 @@ SeqNo = SEQ-NO-TYPE TLV-LENGTH NonNegativeInteger
 MAPPING-DATA-TYPE = 205
 MAPPING-ENTRY-TYPE = 206
 SEQ-NO-TYPE = 204
+```
+
+A `MappingEntry` MAY contain additional information such as the time of publication of the data. Any additional information MUST be encoded as one or more TLV blocks following the `ApplicationName` block. SVS-PS implementations SHOULD provide a mechanism to include additional mapping information, and SHOULD allow applications to filter incoming publications based on the received mapping entry. Implementations MAY also provide mechanisms for automatic handling of well-known additional blocks, such as fetching only recent data based on the `Timestamp` block included in the mapping entry.
+
+The following well-known additional blocks are RECOMMENDED.
+
+```abnf
+Timestamp = TimestampNameComponent
 ```
 
 ## Subscribers


### PR DESCRIPTION
A requirement for one of the projects (probably recurring) is that if a subscriber joins late, then they should not fetch very old data. While this can be done using sequence number or the current known state, that creates issues for network partitions and merging groups.

This can also be potentially done by including the timestamp in the name of the publication itself, but we need to take away this burden from the application.

@Pesa @yoursunny @zjkmxy @tianyuan129